### PR TITLE
Update lib/guard/rails_best_practices.rb

### DIFF
--- a/lib/guard/rails_best_practices.rb
+++ b/lib/guard/rails_best_practices.rb
@@ -1,5 +1,7 @@
 require 'guard'
 require 'guard/guard'
+require 'active_support/core_ext/string' # Fixes undefined method `blank?' for "":String
+
 require File.join(File.dirname(__FILE__), "rails_best_practices/version")
 
 module Guard


### PR DESCRIPTION
When using with Spork and Rails 3.1.1 (don't know what is causing the issue), I get:

Running Rails Best Practices checklist
ERROR: Guard::Rails_best_practices failed to achieve its <start>, exception was:
NoMethodError: undefined method `blank?' for "":String
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-rails_best_practices-0.1.1/lib/guard/rails_best_practices.rb:57:in`run_bestpractices'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-rails_best_practices-0.1.1/lib/guard/rails_best_practices.rb:21:in `start'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:322:in`block in run_supervised_task'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:320:in `catch'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:320:in`run_supervised_task'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:153:in `block in start'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:254:in`block (3 levels) in run_on_guards'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:253:in `each'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:253:in`block (2 levels) in run_on_guards'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:252:in `catch'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:252:in`block in run_on_guards'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:251:in `each'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:251:in`run_on_guards'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard.rb:152:in `start'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/lib/guard/cli.rb:68:in`start'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/thor-0.14.6/lib/thor/invocation.rb:118:in`invoke_task'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/thor-0.14.6/lib/thor/base.rb:389:in`start'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/gems/guard-0.8.8/bin/guard:6:in `<top (required)>'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/bin/guard:19:in`load'
/Users/Matthew/.rvm/gems/ruby-1.9.2-p290/bin/guard:19:in `<main>'

Guard::Rails_best_practices has just been fired

---

It appears that the ActiveSupport core string extension isn't loaded for some reason. I've added a line to require this and it has resolved the issue.
