### PR TITLE
Fix compatibility with 0.9 guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'guard', '>= 0.8.4'
+gem 'guard', '>= 0.9'
 gem 'rails_best_practices', '>= 1.1.0'
 
 # Specify your gem's dependencies in guard-rails_best_practices.gemspec

--- a/guard-rails_best_practices.gemspec
+++ b/guard-rails_best_practices.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('{lib}/**/*') + %w[README.md]
   s.require_paths = ["lib"]
 
-  s.add_dependency "guard", ">= 0.8.4"
+  s.add_dependency "guard", ">= 0.9"
   s.add_dependency "rails_best_practices", ">= 1.1.0"
-  s.add_dependency "active_support"
+  s.add_dependency "activesupport"
 end

--- a/lib/guard/rails_best_practices.rb
+++ b/lib/guard/rails_best_practices.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/string' # Fixes undefined method `blank?' for "
 require File.join(File.dirname(__FILE__), "rails_best_practices/version")
 
 module Guard
-  class Rails_best_practices < Guard
+  class RailsBestPractices < Guard
     autoload :Notifier, 'guard/annotate/notifier'
 
     def initialize(watchers = [], options = {})

--- a/lib/guard/rails_best_practices/notifier.rb
+++ b/lib/guard/rails_best_practices/notifier.rb
@@ -2,9 +2,9 @@
 #
 # Borrowed from guard-annotate
 module Guard
-  class Rails_best_practices
+  class RailsBestPractices
     class Notifier
-      
+
       class << self
         def guard_message( result, duration )
           case result
@@ -14,19 +14,19 @@ module Guard
             "Rails Best Practices checklist run has failed!\nPlease check manually."
           end
         end
-        
+
         def guard_image( result )
           result ? :success : :failed
         end
-        
+
         def notify( result, duration )
           message = guard_message( result, duration )
           image   = guard_image( result )
-          
+
           ::Guard::Notifier.notify( message, :title => 'Rails Best Practices checklist complete', :image => image )
-        end     
+        end
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
This commit renames the class name to work with post 0.9 version of guard. It also fixes Issue #2 with the active_support requirement.
